### PR TITLE
Fix collective.transmogrifier when zope.app.pagetemplate is no longer required by the stack

### DIFF
--- a/src/collective/transmogrifier/utils.py
+++ b/src/collective/transmogrifier/utils.py
@@ -3,7 +3,11 @@ import re
 import sys
 
 from zope.component import getUtility
-from zope.app.pagetemplate import engine
+try:
+    from zope.pagetemplate import engine
+except ImportError:
+    # BBB: Zope 2.10
+    from zope.app.pagetemplate import engine
 
 from interfaces import ISection
 from interfaces import ISectionBlueprint


### PR DESCRIPTION
The alternative is to add an explicit dependency to `zope.app.pagetemplate` in `setup.py`, which could be provided by `fake-eggs` from Zope in Plone 3. setups.
